### PR TITLE
Resizing blockDevPath[]

### DIFF
--- a/src/sdcmd.c
+++ b/src/sdcmd.c
@@ -96,7 +96,7 @@ uint16_t sdFindRca(char* filename)
     unsigned int controller;
     DIR *dir, *dir2;
     char devname[16];
-    char blockDevPath[256];
+    char blockDevPath[512];
     struct dirent *entry;
     int i;
     for(i=strlen(filename)-1; (i>0) && filename[i-1]!='/'; i--);


### PR DESCRIPTION
Hi,
I tried building `sdtool` on an Archlinux 4.12.3, 32bits.

It failed with the following errors :
```console
$ make
gcc -c -Wall -Werror  src/sdcmd.c -o obj/sdcmd.o
src/sdcmd.c: In function 'sdFindRca':
src/sdcmd.c:107:81: error: '%s' directive output may be truncated writing up to 255 bytes into a region of size 235 [-Werror=format-truncation=]
 snprintf (blockDevPath, sizeof(blockDevPath), "/sys/bus/mmc/devices/%s/block/%s", entry->d_name,devname);
                                                                     ^~
src/sdcmd.c:107:13: note: 'snprintf' output 29 or more bytes (assuming 284) into a destination of size 256
             snprintf (blockDevPath, sizeof(blockDevPath), "/sys/bus/mmc/devices/%s/block/%s", entry->d_name,devname);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:53: obj/sdcmd.o] Error 1
```

Changing the size of `char blockDevPath[]` (in `sdcmd.c`) from 256 to something higher than 284 corrected the issue (in this pull request, 512).